### PR TITLE
support multi segment parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "fridays",
   "license": "MIT",
   "dependencies": {
+    "isarray": "^2.0.1",
     "path-to-regexp": "^1.7.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import pathToRegexp from 'path-to-regexp'
 import React from 'react'
 import {parse} from 'url'
+import isarray from 'isarray'
 import Link from 'next/link'
 import Router from 'next/router'
 
@@ -96,10 +97,16 @@ class Route {
   }
 
   getHref (params = {}) {
-    const qs = Object.keys(params).map(key => [
-      encodeURIComponent(key),
-      encodeURIComponent(params[key])
-    ].join('=')).join('&')
+    const qs = Object.keys(params).map(key => {
+      let value = params[key]
+      if (isarray(value)) {
+        value = value.join('/')
+      }
+      return [
+        encodeURIComponent(key),
+        encodeURIComponent(value)
+      ].join('=')
+    }).join('&')
 
     return `${this.page}?${qs}`
   }


### PR DESCRIPTION
Supports following route patterns with multiple segments:
```js
routes.add('page', `/en/:path+`)
```

```js
<Link route='page' params={{path: ['a', 'b']}} />
```

This simply matches [`path-to-regexp` behaviour](https://runkit.com/582b2d3cfc8dba00133fbe80/589a51dc31e2b200154bf5dd):
```
> require("path-to-regexp").compile('/en/:path+')({path: ['a', 'b']})
'/en/a/b'
```

`path-to-regexp` uses `isarray` internally too.