### PR TITLE
Throw error when pushing unknown route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,11 @@ class Routes {
   }
 
   findByName (name) {
-    return this.routes.find(route => route.name === name)
+    const route = this.routes.find(route => route.name === name)
+    if (route === undefined) {
+      throw new Error(`Unknown route: $(name)`)
+    }
+    return route
   }
 
   match (path) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class Routes {
 
   findByName (name) {
     const route = this.routes.find(route => route.name === name)
-    if (route === undefined) {
+    if (!route) {
       throw new Error(`Unknown route: $(name)`)
     }
     return route


### PR DESCRIPTION
Currently `Router.pushRoute('non-existent')` throws:
```
Uncaught TypeError: Cannot read property 'getLinkProps' of undefined
```

Proposing throwing more meaningful error message for debugging reasons.