### PR TITLE
Add support shallow routing fix #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ export default class extends React.Component {
 ```
 API:
 
-`Router.pushRoute(name, params)`
+`Router.pushRoute(name, params, options)`
 
-`Router.replaceRoute(name, params)`
+`Router.replaceRoute(name, params, options)`
 
 - `name` - Name of a route
 - `params` - Optional parameters for the route URL
+- `options` - Optional options
 
 It generates the URL and passes `href` and `as` parameters to `next/router`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,14 +80,14 @@ class Routes {
   }
 
   getRouter (Router) {
-    const pushRoute = (name, params = {}) => {
+    const pushRoute = (name, params = {}, options) => {
       const {href, as} = this.findByName(name).getLinkProps(params)
-      return Router.push(href, as)
+      return Router.push(href, as, options)
     }
 
-    const replaceRoute = (name, params = {}) => {
+    const replaceRoute = (name, params = {}, options) => {
       const {href, as} = this.findByName(name).getLinkProps(params)
-      return Router.replace(href, as)
+      return Router.replace(href, as, options)
     }
 
     return Object.assign(Object.create(Router), {pushRoute, replaceRoute})


### PR DESCRIPTION
## Background

Next.js added support for [Shallow Routing](https://github.com/zeit/next.js/pull/1357) in `Version 2.0.0-beta.37`.
They introduced a third parameter (`options`).
With this PR next-routes will support this param as well.

## Docs

```javascript
Router.pushRoute('about', {foo: 'bar'}, { 
   shallow: true
})

Router.replaceRoute('about', {foo: 'bar'}, { 
   shallow: true
})
```

https://github.com/zeit/next.js#shallow-routing

## Solves

#13

