### PR TITLE
Support full url link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ It generates the URL and passes `href` and `as` props to `next/link`.
 
 #### Href support ####
 
-If you prefer to use `href` our `route` and `params`, simply use the `href` prop. href would be matched to its route and params. However, you need to configure the `origin` option when instantiating nextRoute for SSR.
+If you prefer to use `href` instead of `route` and `params`, simply use the `href` prop. The href would be matched to its route and params. However, you need to configure the `origin` option when instantiating nextRoute for SSR.
 
 ```jsx
 // server.js

--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ API: `<Link route="name" params={params}>...</Link>`
 
 It generates the URL and passes `href` and `as` props to `next/link`.
 
+#### Href support ####
+
+If you prefer to use `href` our `route` and `params`, simply use the `href` prop. href would be matched to its route and params. However, you need to configure the `origin` option when instantiating nextRoute for SSR.
+
+```jsx
+// server.js
+const nextRoutes = require('next-routes')
+const routes = module.exports = nextRoutes({ origin: 'https://mydomain.com' })
+
+// pages/index.js
+import {Link} from '../routes'
+
+export default () => (
+  <div>
+    <div>Welcome to next.js!</div>
+    <Link href='https://mydomain.com/blog/hello-world'>
+      <a>Hello world</a>
+    </Link>
+  </div>
+)
+
+``` 
+
 ---
 
 #### `Router` example

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,8 @@ class Routes {
 
   getLink (Link) {
     return props => {
-      const {route, params, href, ...newProps} = props
+      const {route, params, ...newProps} = props
+      let href = newProps.href
 
       if (route) {
         Object.assign(newProps, this.findByName(route).getLinkProps(params))

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class Routes {
         //  Find matching routes
         const { route, params } = this.match(href)
         if (route) {
-          Object.assign(newProps, { route: route.name, params })
+          Object.assign(newProps, { route: route.name }, route.getLinkProps(params))
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ class Routes {
   constructor ({
     Link = NextLink,
     Router = NextRouter,
-    origin,
+    origin
   } = {}) {
     this.routes = []
     this.Link = this.getLink(Link)

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,13 @@ module.exports = opts => new Routes(opts)
 class Routes {
   constructor ({
     Link = NextLink,
-    Router = NextRouter
+    Router = NextRouter,
+    origin,
   } = {}) {
     this.routes = []
     this.Link = this.getLink(Link)
     this.Router = this.getRouter(Router)
+    this.origin = origin
   }
 
   add (...args) {
@@ -53,10 +55,24 @@ class Routes {
 
   getLink (Link) {
     return props => {
-      const {route, params, ...newProps} = props
+      const {route, params, href, ...newProps} = props
 
       if (route) {
         Object.assign(newProps, this.findByName(route).getLinkProps(params))
+      } else if (href) {
+        //  Get origin, either from browser or config
+        let origin = typeof window !== 'undefined' ? window.location.origin : this.origin
+        //  Convert href to relative
+        if (href === origin) {
+          href = '/'
+        } else if (href.indexOf(`${origin}/`) === 0) {
+          href = href.substring(`${origin}/`.length)
+        }
+        //  Find matching routes
+        const { route, params } = this.match(href)
+        if (route) {
+          Object.assign(newProps, { route: route.name, params })
+        }
       }
 
       return <Link {...newProps} />


### PR DESCRIPTION
In some use cases, links can be user inputs. When a generic url is linked to the application, we want to be able to handle the link click through client side navigation instead of full reload.