### PR TITLE
Supported for using named routes on target _blank

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,14 @@ class Routes {
       const {route, params, ...newProps} = props
 
       if (route) {
-        Object.assign(newProps, this.findByName(route).getLinkProps(params))
+        const linkProps = this.findByName(route).getLinkProps(params)
+      
+        if (newProps.target && newProps.target !== '_self') {
+          Object.assign(newProps, { href: linkProps.href })
+          return <a {...newProps} />
+        } else {
+          Object.assign(newProps, linkProps)
+        }
       }
 
       return <Link {...newProps} />


### PR DESCRIPTION
Hi, I would like to use the route resolution logic here for links that open in a new tab. Unfortunately, next.js does not support the `target` property anchor tag: https://github.com/zeit/next.js/pull/1736, hence we are only able to do the resolution here. Do you think this is a common use case or should I be writing a Link component that somehow uses this?

Cheers!