### PR TITLE
replace includes with indexOf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class Route {
   getAs (params = {}) {
     const as = this.toPath(params)
     const keys = Object.keys(params)
-    const qsKeys = keys.filter(key => !this.keyNames.includes(key))
+    const qsKeys = keys.filter(key => this.keyNames.indexOf(key) !== -1)
 
     if (!qsKeys.length) return as
 


### PR DESCRIPTION
Hi!

About this issue: https://github.com/fridays/next-routes/issues/32

As my investigation at case `When using Router.pushRoute('index', params)` from link above. 
Root cause:
- Because `Array.includes` is not working in iOS 8.4

Solution:
- I replace it with `indexOf`
