### PR TITLE
Shim ES6 methods for IE11 close #27

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "author": "fridays",
   "license": "MIT",
   "dependencies": {
+    "array-find": "^1.0.0",
+    "array-includes": "^3.0.3",
     "path-to-regexp": "^1.7.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import React from 'react'
 import {parse} from 'url'
 import NextLink from 'next/link'
 import NextRouter from 'next/router'
+import find from 'array-find'
+import includes from 'array-includes'
 
 module.exports = opts => new Routes(opts)
 
@@ -22,7 +24,7 @@ class Routes {
   }
 
   findByName (name) {
-    const route = this.routes.find(route => route.name === name)
+    const route = find(this.routes, route => route.name === name)
     if (!route) {
       throw new Error(`Unknown route: ${name}`)
     }
@@ -31,7 +33,7 @@ class Routes {
 
   match (path) {
     let params
-    const route = this.routes.find(route => (params = route.match(path)))
+    const route = find(this.routes, route => (params = route.match(path)))
     return {route, params}
   }
 
@@ -113,7 +115,7 @@ class Route {
   getAs (params = {}) {
     const as = this.toPath(params)
     const keys = Object.keys(params)
-    const qsKeys = keys.filter(key => !this.keyNames.includes(key))
+    const qsKeys = keys.filter(key => !includes(this.keyNames, key))
 
     if (!qsKeys.length) return as
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,17 @@ arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"


### PR DESCRIPTION
To solve problems in IE 11 and make this lib easy to use we need to shim ES6 methods:

* [x] `Object.assign` - polyfilled by `next.js`
* [x] `Array.find` - ponyfilled by this PR
* [x] `Array.includes` - ponyfilled by this PR

I am not a big fan of this because I believe it is the job of [preset-env](https://github.com/babel/babel-preset-env) to add such polyfills.
Nevertheless right now it is pretty complex to configure it via `next.config.js`

What do you think about this PR @fridays?

**Status:** ⚠️  Not tested 