### PR TITLE
Link to a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,33 +86,28 @@ export default () => (
     <Link route='blog' params={{slug: 'hello-world'}}>
       <a>Hello world</a>
     </Link>
-  </div>
-)
-
-```
-
-```jsx
-// pages/index.js
-import {Link} from '../routes'
-
-export default () => (
-  <div>
-    <div>Welcome to next.js!</div>
-    <Link path='/some-path-conform-to-a-route-patter'>
-      <a>Hello world</a>
+    <Link path='/about-section'>
+      <a>About</a>
     </Link>
   </div>
 )
-
 ```
 
-API: `<Link route="name" params={params}>...</Link>`
+API: `<Link route="name" href="path" params={params}>...</Link>`
 
 - `route` - Name of a route
 - `params` - Optional parameters for the route URL
-- `path`- A path supposed to follow a route pattern. From the path the right route and params are found. NOTE: `path`and `route` exclusive and if present `route` takes precedence over `path`.
+- `href`- A path supposed to follow a route pattern.
 
 It generates the URL and passes `href` and `as` props to `next/link`. Other props like `prefetch` will work as well.
+`href` takes precedence over `route`. The steps follow the next logic:
+
+- If `href` not is present then use `route`.
+- If `href` is present, try to looking for a route that match the path
+  - If a route is found then use it,
+  - If a route is not found then
+    - if `route` property is present then use it
+    - otherwise pass the `href` to `next/link`
 
 ---
 
@@ -143,7 +138,7 @@ API:
 
 `Router.pushRoute(name, params, options)`
 
-`Router.pushRoute(path, options)`
+`Router.pushHref(href, options)`: Push the given `href`. First tries to find a router that match the `href`. If none if found then the `href` is passed directly to nextjs so it changes the navigation to the page specified by `href`.
 
 `Router.replaceRoute(name, params, options)`
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ app.prepare().then(() => {
 
 ### On the client
 
-Thin wrappers around `Link` and `Router` add support for generated URLs based on route name and parameters. Just import them from your `routes` file:
+Thin wrappers around `Link` and `Router` add support for generated URLs based on route name and parameters or path url. Just import them from your `routes` file:
 
 #### `Link` example
 
@@ -91,10 +91,26 @@ export default () => (
 
 ```
 
+```jsx
+// pages/index.js
+import {Link} from '../routes'
+
+export default () => (
+  <div>
+    <div>Welcome to next.js!</div>
+    <Link path='/some-path-conform-to-a-route-patter'>
+      <a>Hello world</a>
+    </Link>
+  </div>
+)
+
+```
+
 API: `<Link route="name" params={params}>...</Link>`
 
 - `route` - Name of a route
 - `params` - Optional parameters for the route URL
+- `path`- A path supposed to follow a route pattern. From the path the right route and params are found. NOTE: `path`and `route` exclusive and if present `route` takes precedence over `path`.
 
 It generates the URL and passes `href` and `as` props to `next/link`. Other props like `prefetch` will work as well.
 
@@ -126,6 +142,8 @@ export default class extends React.Component {
 API:
 
 `Router.pushRoute(name, params, options)`
+
+`Router.pushRoute(path, options)`
 
 `Router.replaceRoute(name, params, options)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,10 +55,15 @@ class Routes {
 
   getLink (Link) {
     const LinkRoutes = props => {
-      const {route, params, ...newProps} = props
+      const {route, params, path, ...newProps} = props
 
       if (route) {
         Object.assign(newProps, this.findByName(route).getLinkProps(params))
+      }
+
+      if (path) {
+        const {route: routeObj, params: paramsObj} = this.match(path)
+        Object.assign(newProps, routeObj.getLinkProps(paramsObj))
       }
 
       return <Link {...newProps} />
@@ -67,6 +72,12 @@ class Routes {
   }
 
   getRouter (Router) {
+    Router.pushPath = (path, options) => {
+      const {route: routeObj, params: paramsObj} = this.match(path)
+      const {href, as} = routeObj.getLinkProps(paramsObj)
+      return Router.push(href, as, options)
+    }
+
     Router.pushRoute = (name, params = {}, options) => {
       const {href, as} = this.findByName(name).getLinkProps(params)
       return Router.push(href, as, options)

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class Routes {
       // then use the route property. Finally use href if it is present but no
       // route match it and no route property is specified.
       if (routeObj) {
-          Object.assign(newProps, routeObj.getLinkProps(paramsObj))
+        Object.assign(newProps, routeObj.getLinkProps(paramsObj))
       } else {
         if (route) {
           Object.assign(newProps, this.findByName(route).getLinkProps(params))


### PR DESCRIPTION
In addition to link to a route with params we can also link to a given path that conforms a route pattern.

In my case I have complex route patterns which extracts some variables from the path. I want to be able to Link to a different path and use the power of regexp to extract again the variables from the path instead to compute the route with params.