### PR TITLE
Refactor use of Object.assign to spread operator.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,10 +55,13 @@ class Routes {
 
   getLink (Link) {
     const LinkRoutes = props => {
-      const {route, params, ...newProps} = props
+      let {route, params, ...newProps} = props
 
       if (route) {
-        Object.assign(newProps, this.findByName(route).getLinkProps(params))
+        newProps = {
+          ...newProps,
+          ...this.findByName(route).getLinkProps(params)
+        }
       }
 
       return <Link {...newProps} />
@@ -104,9 +107,10 @@ class Route {
   }
 
   valuesToParams (values) {
-    return values.reduce((params, val, i) => Object.assign(params, {
+    return values.reduce((params, val, i) => ({
+      ...params,
       [this.keys[i].name]: val
-    }), {})
+    }))
   }
 
   getHref (params = {}) {
@@ -120,9 +124,10 @@ class Route {
 
     if (!qsKeys.length) return as
 
-    const qsParams = qsKeys.reduce((qs, key) => Object.assign(qs, {
+    const qsParams = qsKeys.reduce((qs, key) => ({
+      ...qs,
       [key]: params[key]
-    }), {})
+    }))
 
     return `${as}?${toQuerystring(qsParams)}`
   }


### PR DESCRIPTION
Fixes https://github.com/fridays/next-routes/issues/53.

Without understanding the source, I tried to faithfully recreate the logic using spread operator syntax. I am not sure how to test each of the functions that was changed, so I suggest looking over it carefully. It at least seems ok with `pushRoute` in my app, and IE 11 is now happy.