### PR TITLE
Add route resolution by URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easy to use universal named routes for [next.js](https://github.com/zeit/next.js
 
 - Express-style route and parameters matching
 - Request handler middleware for express & co
-- `Link` and `Router` that generate URLs by route name
+- `Link` and `Router` that generate URLs by route definition
 
 ## How to use
 
@@ -78,7 +78,7 @@ const handler = routes.getRequestHandler(app, ({req, res, route, query}) => {
 
 ### On the client
 
-Thin wrappers around `Link` and `Router` add support for generated URLs based on route name and parameters. Just import them from your `routes` file:
+Thin wrappers around `Link` and `Router` add support for generated URLs based on route definition. Just import them from your `routes` file:
 
 #### `Link` example
 
@@ -92,6 +92,10 @@ export default () => (
     <Link route='blog' params={{slug: 'hello-world'}}>
       <a>Hello world</a>
     </Link>
+    or:
+    <Link route='/blog/hello-world'>
+      <a>Hello world</a>
+    </Link>
   </div>
 )
 
@@ -99,7 +103,9 @@ export default () => (
 
 API: `<Link route="name" params={params}>...</Link>`
 
-- `route` - Name of a route
+Or: `<Link route="/path/to/match">...</Link>`
+
+- `route` - Name of a route or URL to match
 - `params` - Optional parameters for the route URL
 
 It generates the URL and passes `href` and `as` props to `next/link`. Other props like `prefetch` will work as well.
@@ -116,6 +122,8 @@ import {Router} from '../routes'
 export default class extends React.Component {
   handleClick () {
     Router.pushRoute('about', {foo: 'bar'})
+    // or
+    Router.pushRoute('/about-us/bar')
   }
   render () {
     return (
@@ -131,15 +139,17 @@ export default class extends React.Component {
 ```
 API:
 
-`Router.pushRoute(name, params, options)`
+`Router.pushRoute(route, params, options)`
 
-`Router.replaceRoute(name, params, options)`
+`Router.replaceRoute(route, params, options)`
 
-- `name` - Name of a route
+`Router.prefetchRoute(route, params)`
+
+- `route` - Name of a route or URL to match
 - `params` - Optional parameters for the route URL
-- `options` - Optional options
+- `options`
 
-It generates the URL and passes `href` and `as` parameters to `next/router`.
+It generates the URL and passes `url` and `as` parameters to `next/router`.
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,8 +94,10 @@ class Routes {
           const {href, as} = route.getLinkProps(params)
           return Router[fn](href, as, options)
         } else {
-          const {route, params, query} = this.match(routeProp)
-          const url = route ? route.getHref({...query, ...params}) : routeProp
+          options = options || params
+          const {route, params: matchParams, query} = this.match(routeProp)
+          Object.assign(query, matchParams)
+          const url = route ? route.getHref(query) : routeProp
           return Router[fn](url, routeProp, options)
         }
       }


### PR DESCRIPTION
Adds the possibility to resolve routes by URL in addition to name.

```javascript
routes.add('blog', '/blog/:slug')
```
```jsx
<Link route='/blog/hello-world'><a>Click</a></Link>
```
```javascript
Router.pushRoute('/blog/hello-world')
Router.replaceRoute('/blog/hello-world')
Router.prefetchRoute('/blog/hello-world')
```
The interface didn't change. If no route was found by name, it tries to find one by matching it against the patterns. If still no route was found, it passes it on to `next` as it came in.

Closes #46 closes #23