### PR TITLE
Add support for unnamed routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,20 @@ Create `routes.js` inside your project root:
 const nextRoutes = require('next-routes')
 const routes = module.exports = nextRoutes()
 
+// Named routes
 routes.add('blog', '/blog/:slug')
 routes.add('about', '/about-us/:foo(bar|baz)', 'index')
+
+// Unnamed routes
+routes.add('/some/:thing', 'page')
 ```
 This file is used both on the server and the client.
 
 API: `routes.add(name, pattern, page = name)`
 
-- `name` - The route name
+- `name` - Optional: The route name
 - `pattern` - Express-style route pattern (uses [path-to-regexp](https://github.com/pillarjs/path-to-regexp))
-- `page` - Page inside `./pages` to be rendered (defaults to `name`)
+- `page` - Page inside `./pages` to be rendered. Optional for named routes (defaults to `name`), mandatory for unnamed routes.
 
 The page component receives the matched URL parameters merged into `query`
 

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,16 @@ class Routes {
 
 class Route {
   constructor (name, pattern, page = name) {
+    if (name.charAt(0) === '/') {
+      page = pattern
+      pattern = name
+      name = null
+
+      if (!page) {
+        throw new Error(`Please define a page to render for route "${pattern}"`)
+      }
+    }
+
     this.name = name
     this.pattern = pattern || `/${name}`
     this.page = page.replace(/^\/?(.*)/, '/$1')


### PR DESCRIPTION
Following https://github.com/fridays/next-routes/pull/58 this adds support for unnamed routes.

It assumes a route is unnamed if the first parameter starts with `/`

In this case, the page to render is mandatory and it will throw an error if it's not present.

```javascript
routes.add('/blog/:slug', 'blog')
```
```jsx
<Link route='/blog/hello-world'><a>Click</a></Link>
```