### PR TITLE
Standard version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,13 @@ All notable changes to this project will be documented in this file. See [standa
 ### Features
 
 * Use standard-version to manage creating of CHANGELOG.md, bump package version and tag creation ([43f1021](https://github.com/fridays/next-routes/commit/43f1021))
+
+
+
+<a name="1.0.40"></a>
+## 1.0.40 (2017-07-16)
+
+
+### Features
+
+* Use standard-version to manage creating of CHANGELOG.md, bump package version and tag creation ([43f1021](https://github.com/fridays/next-routes/commit/43f1021))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="1.0.40"></a>
+## 1.0.40 (2017-07-16)
+
+
+### Features
+
+* Use standard-version to manage creating of CHANGELOG.md, bump package version and tag creation ([43f1021](https://github.com/fridays/next-routes/commit/43f1021))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Dynamic Routes for Next.js
 
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![npm version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=js&type=6&v=1.0.40&x2=0)](https://www.npmjs.com/package/next-routes) [![Coverage Status](https://coveralls.io/repos/github/fridays/next-routes/badge.svg)](https://coveralls.io/github/fridays/next-routes) [![Build Status](https://travis-ci.org/fridays/next-routes.svg?branch=master)](https://travis-ci.org/fridays/next-routes)
 
 Easy to use universal dynamic routes for [Next.js](https://github.com/zeit/next.js)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "npm run testOnly",
     "testOnly": "jest \\.test.js --coverage",
     "testCI": "npm run test && cat coverage/lcov.info | coveralls",
-    "dev": "concurrently -k 'npm run build -- -w' 'npm run testOnly -- --watch'"
+    "dev": "concurrently -k 'npm run build -- -w' 'npm run testOnly -- --watch'",
+    "release": "standard-version"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1",
-    "standard": "^10.0.2"
+    "standard": "^10.0.2",
+    "standard-version": "^4.2.0"
   },
   "author": "fridays",
   "license": "MIT",


### PR DESCRIPTION
Add [standard-version](https://github.com/conventional-changelog/standard-version) package to manage:

- bumps the version in package.json/bower.json (based on your commit history)
- uses conventional-changelog to update CHANGELOG.md
- commits package.json (et al.) and CHANGELOG.md
- tags a new release

Using it is as easy as:

- To create the first release: `npm run release -- --first-release`
- Next release use: `npm run release -- --release-as [major|minor|patch|$VERSION]`, where $version is whatever you want, like `1.1.0`.