### PR TITLE
Feature/support anchor hashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,12 +100,6 @@ class Routes {
             as: `${newProps.as}#${hash}`
           })
         }
-      } else if (hash && newProps.href && typeof newProps.href === 'string') {
-        if (newProps.href.indexOf('#') < 0) {
-          Object.assign(newProps, {
-            href: { pathname: newProps.href, hash: hash }
-          })
-        }
       }
 
       return <Link {...newProps} />

--- a/src/index.js
+++ b/src/index.js
@@ -89,11 +89,23 @@ class Routes {
 
   getLink (Link) {
     const LinkRoutes = props => {
-      const {route, params, to, ...newProps} = props
+      const {route, params, to, hash, ...newProps} = props
       const nameOrUrl = route || to
 
       if (nameOrUrl) {
         Object.assign(newProps, this.findAndGetUrls(nameOrUrl, params).urls)
+        if (hash) {
+          Object.assign(newProps, {
+            href: `${newProps.href}#${hash}`,
+            as: `${newProps.as}#${hash}`
+          })
+        }
+      } else if (hash && newProps.href && typeof newProps.href === 'string') {
+        if (newProps.href.indexOf('#') < 0) {
+          Object.assign(newProps, {
+            href: { pathname: newProps.href, hash: hash }
+          })
+        }
       }
 
       return <Link {...newProps} />

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,6 +148,32 @@ describe('Link', () => {
   test('without route', () => {
     setup('a').testLink({href: '/'}, {href: '/'})
   })
+
+  describe('anchor hashes', () => {
+    test('with route url', () => {
+      setup('/a/:b', 'a').testLink({route: '/a/b', hash: 'abc'}, {href: '/a?b=b#abc', as: '/a/b#abc'})
+    })
+
+    test('with to', () => {
+      setup('/a/:b', 'a').testLink({to: '/a/b', hash: 'abc'}, {href: '/a?b=b#abc', as: '/a/b#abc'})
+    })
+
+    test('with route not found', () => {
+      setup('a').testLink({route: '/b', hash: 'abc'}, {href: '/b#abc', as: '/b#abc'})
+    })
+
+    test('without route', () => {
+      setup('a').testLink({href: '/', hash: 'abc'}, {href: {pathname: '/', hash: 'abc'}})
+    })
+
+    test('without route but with existing hash', () => {
+      setup('a').testLink({href: '/#zyx', hash: 'abc'}, {href: '/#zyx'})
+    })
+
+    test('without route using next\'s Link href object', () => {
+      setup('a').testLink({href: {pathname: '/', hash: 'abc'}}, {href: {pathname: '/', hash: 'abc'}})
+    })
+  })
 })
 
 const routerMethods = ['push', 'replace', 'prefetch']

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,15 +162,15 @@ describe('Link', () => {
       setup('a').testLink({route: '/b', hash: 'abc'}, {href: '/b#abc', as: '/b#abc'})
     })
 
-    test('without route', () => {
-      setup('a').testLink({href: '/', hash: 'abc'}, {href: {pathname: '/', hash: 'abc'}})
+    test('with href drops hash prop (user needs to handle)', () => {
+      setup('a').testLink({href: '/', hash: 'abc'}, {href: '/'})
     })
 
-    test('without route but with existing hash', () => {
+    test('with href drops hash prop (user needs to handle)', () => {
       setup('a').testLink({href: '/#zyx', hash: 'abc'}, {href: '/#zyx'})
     })
 
-    test('without route using next\'s Link href object', () => {
+    test('with href using next\'s Link href object', () => {
       setup('a').testLink({href: {pathname: '/', hash: 'abc'}}, {href: {pathname: '/', hash: 'abc'}})
     })
   })


### PR DESCRIPTION
The Link component should handle getting an anchor hash parameter and creating the correct `href` and `as` values.  

If the user is passing in `href` then ignore the hash parameter as the user can build the proper url object themselves. We just make sure it gets passed to next's Link correctly.


