### PR TITLE
Do not encode null values for params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,9 @@ class Route {
 
 const toQuerystring = obj => Object.keys(obj).map(key => {
   let value = obj[key]
+  if (value === null) {
+    value = ''
+  }
   if (Array.isArray(value)) {
     value = value.join('/')
   }

--- a/src/index.js
+++ b/src/index.js
@@ -169,16 +169,16 @@ class Route {
   }
 }
 
-const toQuerystring = obj => Object.keys(obj).map(key => {
-  let value = obj[key]
-  if (value === null) {
-    value = ''
-  }
-  if (Array.isArray(value)) {
-    value = value.join('/')
-  }
-  return [
-    encodeURIComponent(key),
-    encodeURIComponent(value)
-  ].join('=')
-}).join('&')
+const toQuerystring = obj => Object.keys(obj)
+  .filter(key => obj[key] !== null && obj[key] !== undefined)
+  .map(key => {
+    let value = obj[key]
+
+    if (Array.isArray(value)) {
+      value = value.join('/')
+    }
+    return [
+      encodeURIComponent(key),
+      encodeURIComponent(value)
+    ].join('=')
+  }).join('&')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,14 @@ describe('Routes', () => {
     expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
   })
 
+  test('do not pass "null" for params that have null values', () => {
+    const {route} = setup('a', '/a/:b/:c?')
+    const params = {b: 'b', c: null}
+    const expected = {as: '/a/b', href: '/a?b=b&c='}
+    expect(route.getUrls(params)).toEqual(expected)
+    expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
+  })
+
   test('ensure "as" when path match is empty', () => {
     expect(setup('a', '/:a?').route.getAs()).toEqual('/')
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,8 +76,8 @@ describe('Routes', () => {
 
   test('do not pass "null" for params that have null values', () => {
     const {route} = setup('a', '/a/:b/:c?')
-    const params = {b: 'b', c: null}
-    const expected = {as: '/a/b', href: '/a?b=b&c='}
+    const params = {b: 'b', c: null, d: undefined}
+    const expected = {as: '/a/b?', href: '/a?b=b'}
     expect(route.getUrls(params)).toEqual(expected)
     expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
   })


### PR DESCRIPTION
If you have an object with the following properties: 
```
const myObj = {
  foo: 42,
  bar: null
}
```
And then use that object in the Link params, like so: 
```
<Link route="fridaysAwesome" params={{ prop.foo, prop.bar }}>...</Link>
```

The resultant query object passed to components is the following: 
```
//query
{
  foo: 42,
  bar: "null"
}
```

as a result of `encodeURIComponent(null)`