### PR TITLE
Escaped params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,9 @@ class Routes {
       if (result.route) return result
       const params = route.match(pathname)
       if (!params) return result
+      Object.keys(params).forEach((key) => {
+        params[key] = decodeURIComponent(params[key])
+      })
       return {...result, route, params, query: {...query, ...params}}
     }, {query, parsedUrl})
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,6 +66,13 @@ describe('Routes', () => {
     expect(query).not.toHaveProperty('a')
   })
 
+  test('match and merge escaped params', () => {
+    const routes = nextRoutes().add('a', '/a/:b')
+    const {query} = routes.match('/a/b%20%2F%20b')
+    expect(query).toMatchObject({b: 'b / b'})
+    expect(query).not.toHaveProperty('a')
+  })
+
   test('generate urls from params', () => {
     const {route} = setup('a', '/a/:b/:c+')
     const params = {b: 'b', c: [1, 2], d: 'd'}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,14 @@ describe('Routes', () => {
     expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
   })
 
+  test('generate urls with params that need escaping', () => {
+    const {route} = setup('a', '/a/:b')
+    const params = {b: 'b b'}
+    const expected = {as: '/a/b%20b', href: '/a?b=b%20b'}
+    expect(route.getUrls(params)).toEqual(expected)
+    expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
+  })
+
   test('do not pass "null" for params that have null values', () => {
     const {route} = setup('a', '/a/:b/:c?')
     const params = {b: 'b', c: null, d: undefined}


### PR DESCRIPTION
When urls are constructed in the `Link` component, all params are URI
encoded so that they won't break routing. When params are read however,
they are never decoded. This leads to an inconsistent behavior between
the server and the client when params are passed down the page component
as `query`. On the server, they come down untouched (encoded). On the
client, they are not encoded.

Consider this link:

```
  <Link route="foo" params={{ b: 'f/g' }}><a>Foo</a></Link>
```

and this page component

```
  FooPage.getInitialProps = async ({ query }) => {
    console.log(query.b);
  }
```

On the server, this page would log "f%2Fg" when navigated to. On the
client it would log "f/g".

By decoding params before they are injected into the `query` params, we
get the same behavior on the client and the server. We also make the
behavior consistent with how regular query params work.