### PR TITLE
fix: switch wildcard imports for more specific named imports [typescript]

### DIFF
--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -1,12 +1,12 @@
-import http from "http";
-import next from "next";
+import { IncomingMessage, ServerResponse } from "http";
+import { Server } from "next";
 import { ComponentType } from "react";
 import { LinkState } from "next/link";
 import { SingletonRouter, EventChangeOptions } from "next/router";
 
 export type HTTPHandler = (
-  request: http.IncomingMessage,
-  response: http.ServerResponse
+  request: IncomingMessage,
+  response: ServerResponse
 ) => void;
 
 export type RouteParams = {
@@ -36,7 +36,7 @@ export interface Router extends SingletonRouter {
 }
 
 export interface Registry {
-  getRequestHandler(app: next.Server, custom?: HTTPHandler): HTTPHandler;
+  getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
   add(options: { name: string; pattern?: string; page?: string }): this;
@@ -45,7 +45,7 @@ export interface Registry {
 }
 
 export default class Routes implements Registry {
-  getRequestHandler(app: next.Server, custom?: HTTPHandler): HTTPHandler;
+  getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
   add(options: { name: string; pattern?: string; page?: string }): this;

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -1,5 +1,5 @@
-import http from "http";
-import next from "next";
+import * as http from "http";
+import * as next from "next";
 import Routes from "../..";
 
 const routes = new Routes();

--- a/typings/tests/tsconfig.json
+++ b/typings/tests/tsconfig.json
@@ -4,16 +4,11 @@
     "module": "esnext",
     "noEmit": true,
     "jsx": "react",
-
     "strict": true,
-
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
The default imports in the module typings were not necessary. Instead, we used imports and select the exact bits we need out of http and next. This has the nice side-effect of being compatible with environments where esModuleInterop is either true or false.