### PR TITLE
refacor(src) use export deafult based syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: node_js
 node_js:
+  - "lts/*"
   - "6"
-script: npm run testCI
+env:
+  matrix:
+  - CMD=build
+  - CMD=lint
+  - CMD=testCI
+script: npm run $CMD

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+####    WhiteSource Integration configuration file    ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install next-routes --save
 Create `routes.js` inside your project:
 
 ```javascript
-const routes = require('next-routes')
+const routes = require('next-routes').default
 
                                                     // Name   Page      Pattern
 module.exports = routes()                           // ----   ----      -----

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,9 @@ import {parse} from 'url'
 import NextLink from 'next/link'
 import NextRouter from 'next/router'
 
-module.exports = opts => new Routes(opts)
+export default opts => new Routes(opts)
 
-class Routes {
+export class Routes {
   constructor ({
     Link = NextLink,
     Router = NextRouter

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -44,7 +44,7 @@ export interface Registry {
   Router: Router;
 }
 
-export default class Routes implements Registry {
+export class Routes implements Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
@@ -52,3 +52,5 @@ export default class Routes implements Registry {
   Link: ComponentType<LinkProps>;
   Router: Router;
 }
+
+export default Routes

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -53,4 +53,5 @@ export class Routes implements Registry {
   Router: Router;
 }
 
-export default Routes
+declare const _default: (opt: any) => Routes
+export default _default

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -53,5 +53,9 @@ export class Routes implements Registry {
   Router: Router;
 }
 
-declare const _default: (opt: any) => Routes
-export default _default
+export interface RoutesOptions {
+  Link: ComponentType<LinkProps>;
+  Router: Router;
+}
+
+export default function makeRoutesRegistry (options?: RoutesOptions): Routes;

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -1,6 +1,6 @@
 import * as http from "http";
 import * as next from "next";
-import Routes from "../..";
+import { Routes } from "../..";
 
 const routes = new Routes();
 


### PR DESCRIPTION
When using with TypeScript

```typescript
// ts
import Route from 'next-routes' // (opt: any) => Routes
// We expect the class to come in type definition
// https://github.com/fridays/next-routes/blob/master/typings/next-routes.d.ts#L47
```

```js
// es
import routes from 'next-routes'

routes({}).add(...)
```
