### PR TITLE
Add router event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ export default class Blog extends React.Component {
 }
 ```
 
+## Router Events
+
+The following router events are supported:
+
+- onRouteChangeStart
+- onRouteChangeComplete
+- onRouteChangeError
+- onBeforeHistoryChange
+
+```javascript
+const routes = module.exports = require('next-routes')()
+
+routes
+.add('about')
+
+routes.onRouteChangeStart((url) => {
+  console.log('App is changing to: ', url);
+})
+```
+
+API:
+
+- `routes.onRouteChangeStart(url)`
+- `routes.onRouteChangeComplete(url)`
+- `routes.onRouteChangeError(err, url)`
+- `routes.onBeforeHistoryChange(url)`
+
+---
+
 ## On the server
 
 ```javascript

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,19 @@ class Routes {
     }
   }
 
+  onRouteChangeStart (fn) {
+    this.Router.onRouteChangeStart = fn;
+  }
+  onRouteChangeComplete (fn) {
+    this.Router.onRouteChangeComplete = fn;
+  }
+  onRouteChangeError (fn) {
+    this.Router.onRouteChangeError = fn;
+  }
+  onBeforeHistoryChange (fn) {
+    this.Router.onBeforeHistoryChange = fn;
+  }
+
   getLink (Link) {
     const LinkRoutes = props => {
       const {route, params, to, ...newProps} = props


### PR DESCRIPTION
nextjs supports handeling router events https://nextjs.org/docs#routing

onRouteChangeStart
onRouteChangeComplete
onRouteChangeError
onBeforeHistoryChange

This branch adds those events to next-routes with the following syntax:
```
routes.onRouteChangeStart((url) => {
  console.log('App is changing to: ', url);
})
```

Related to these issues
- https://github.com/fridays/next-routes/issues/112
- https://github.com/fridays/next-routes/issues/189