### PR TITLE
Add support to pass pathToRegexp options

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -108,6 +108,31 @@ describe('Routes', () => {
     expect(renderer.render(<Link />).type).toBe(CustomLink)
     expect(Router).toBe(CustomRouter)
   })
+
+  test('with global pathToRegexp options', () => {
+    const pathToRegexpOpts = {sensitive: true}
+    const routes = nextRoutes({pathToRegexpOpts}).add('a', '/A')
+    const route = routes.findByName('a')
+    expect(route.regex.toString().includes('/i')).toBeFalsy()
+  })
+
+  test('with route pathToRegexp options', () => {
+    const routes = nextRoutes()
+      .add({name: 'b', pattern: '/b', opts: {pathToRegexp: {sensitive: true}}})
+      .add('c', '/c', 'c', {pathToRegexp: {strict: true}})
+    const routeB = routes.findByName('b')
+    expect(routeB.regex.toString().includes('/i')).toBeFalsy()
+    const routeC = routes.findByName('c')
+    expect(routeC.regex.toString().includes('(?:\\/)')).toBeFalsy()
+  })
+
+  test('global and route pathToRegexp options are merged', () => {
+    const routes = nextRoutes({pathToRegexpOpts: {sensitive: true, strict: false}})
+      .add('a', '/a', 'a', {pathToRegexp: {strict: true}})
+    const route = routes.findByName('a')
+    expect(route.regex.toString().includes('(?:\\/)')).toBeFalsy()
+    expect(route.regex.toString().includes('/i')).toBeFalsy()
+  })
 })
 
 describe('Request handler', () => {

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -3,11 +3,14 @@ import { Server } from "next";
 import { ComponentType } from "react";
 import { LinkState } from "next/link";
 import { SingletonRouter, EventChangeOptions } from "next/router";
+import { RegExpOptions, ParseOptions } from 'path-to-regexp'
 
 export type HTTPHandler = (
   request: IncomingMessage,
   response: ServerResponse
 ) => void;
+
+export type PathToRegexpOptions = ParseOptions & RegExpOptions
 
 export type RouteParams = {
   [k: string]: string | number;
@@ -46,9 +49,10 @@ export interface Registry {
 
 export default class Routes implements Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
-  add(name: string, pattern?: string, page?: string): this;
-  add(pattern: string, page: string): this;
-  add(options: { name: string; pattern?: string; page?: string }): this;
+  add(name: string, pattern?: string, page?: string, opts?: { pathToRegexp?: PathToRegexpOptions}): this;
+  add(pattern: string, page: string, opts?: { pathToRegexp?: PathToRegexpOptions}): this;
+  add(options: { name: string; pattern?: string; page?: string, opts?: { pathToRegexp?: PathToRegexpOptions}}): this;
   Link: ComponentType<LinkProps>;
   Router: Router;
+  pathToRegexpOpts: PathToRegexpOptions
 }

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -7,9 +7,10 @@ const routes = new Routes();
 routes
   .add("login")
   .add("home", "/", "index")
+  .add("category", "/c/:id", "category", { pathToRegexp: { strict: true }})
   .add("/settings", "/users/:id/settings")
   .add("/example", "example")
-  .add({ name: "objectstyle", pattern: "/cool", page: "cool" });
+  .add({ name: "objectstyle", pattern: "/Cool", page: "cool", opts: { pathToRegexp: { sensitive: true }}});
 
 export const createServer = () => {
   const app = next({ dev: true });


### PR DESCRIPTION
- **pathToRegexp options**
  - **sensitive** When `true` the route will be case sensitive. (default: `false`)
  - **strict** When `false` the trailing slash is optional. (default: `false`)
  - **end** When `false` the path will match at the beginning. (default: `true`)

Routes can be further customised if we can change the default pathToRegexp options, I'm proposing 2 ways to do that.

**1 - Global pathToRegexp options passing them to the `Routes` constructor.**
```
const pathToRegexpOpts = {sensitive: true}
const routes = nextRoutes({pathToRegexpOpts})
  .add('/Category/:id', 'category')
  .add('/category/:id', 'other_category')
```

This would solve https://github.com/fridays/next-routes/issues/147.

**2 - Per route pathToRegexp options passing them to the `add` function.**
```
const routes = nextRoutes().add('c', '/c', 'c', {pathToRegexp: {strict: true}})
```

Per route options would be merged with global options.


This implementation shouldn't break the current usage. I'm planning to update the documentation to explain the usage in another commit if you like the PR.