### PR TITLE
support custom-server-typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ export default class Blog extends React.Component {
 }
 ```
 
+TypeScript:
+
+```typescript
+import * as Routes from "../..";
+
+const routes = Routes();
+...
+```
+
 ## On the server
 
 ```javascript

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -4,21 +4,21 @@ import { ComponentType } from "react";
 import { LinkState } from "next/link";
 import { SingletonRouter, EventChangeOptions } from "next/router";
 
-export type HTTPHandler = (
+type HTTPHandler = (
   request: IncomingMessage,
   response: ServerResponse
 ) => void;
 
-export type RouteParams = {
+type RouteParams = {
   [k: string]: string | number;
 };
 
-export interface LinkProps extends LinkState {
+interface LinkProps extends LinkState {
   route: string;
   params?: RouteParams;
 }
 
-export interface Router extends SingletonRouter {
+interface Router extends SingletonRouter {
   pushRoute(
     route: string,
     params?: RouteParams,
@@ -35,7 +35,7 @@ export interface Router extends SingletonRouter {
   ): Promise<React.ComponentType<any>>;
 }
 
-export interface Registry {
+interface Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
@@ -44,7 +44,12 @@ export interface Registry {
   Router: Router;
 }
 
-export default class Routes implements Registry {
+interface Opts {
+  Link?: ComponentType<LinkProps>;
+  Router?: Router;
+}
+
+declare class Routes implements Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
@@ -52,3 +57,7 @@ export default class Routes implements Registry {
   Link: ComponentType<LinkProps>;
   Router: Router;
 }
+
+declare function routes(opts?: Opts): Routes;
+declare namespace routes {}
+export = routes;

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -1,8 +1,8 @@
 import * as http from "http";
 import * as next from "next";
-import Routes from "../..";
+import * as Routes from "../..";
 
-const routes = new Routes();
+const routes = Routes();
 
 routes
   .add("login")


### PR DESCRIPTION
Currently there is an issue within [custom-server-typescript](https://github.com/zeit/next.js/tree/canary/examples/custom-server-typescript) case.

Ex 1: 
```typescript
import Routes from 'next-routes';
const routes = new Routes();
```

Then result is like following.

```
const routes = new Routes();
              ^
TypeError: next_routes_1.default is not a constructor
```

Ex 2:

```typescript
import Routes = require('next-routes');
const routes = new Routes(); // Without new, anather error appeared
export default routes;

```

Then

```
TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.

TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("/Users/vwxyutarooo/Projects/vwxyutarooo/custom-server-typescript/node_modules/next...' has no compatible call signatures.
```

I think basically this issue caused by declaration and hope this might correct way to fix it.