### PR TITLE
Merge query string into params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class Routes {
       if (result.route) return result
       const params = route.match(pathname)
       if (!params) return result
-      return {...result, route, params, query: {...query, ...params}}
+      return {...result, route, params: {...query, ...params}, query: {...query, ...params}}
     }, {query, parsedUrl})
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -59,6 +59,12 @@ describe('Routes', () => {
     setup('index', '/').testRoute({page: '/'})
   })
 
+  test('merge query string into params', () => {
+    const routes = nextRoutes().add('a', '/a/:slug/reviews')
+    const {params} = routes.match('/a/some-slug/reviews?page=1')
+    expect(params).toMatchObject({slug: 'some-slug', page: '1'})
+  })
+
   test('match and merge params into query', () => {
     const routes = nextRoutes().add('a').add('b', '/:a?/b/:b').add('c')
     const {query} = routes.match('/b/b?b=x&c=c')


### PR DESCRIPTION
We are running into an issue adding query strings to Next routes. For example, when viewing a "reviews" page like so - `/someurl/:slug/reviews` we need to paginate with a query string like - 

`/someurl/my-slug/reviews?page=1`

This works fine if you push a shallow route with `Link` however, on SSR reloads, only the named param segments are added to the `props.url.query` for the page. This fixes this by merging `params` and the `query` with named params taking precedence 