### PR TITLE
Fix type definition for default export

### DIFF
--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -4,6 +4,9 @@ import { ComponentType } from "react";
 import { LinkState } from "next/link";
 import { SingletonRouter, EventChangeOptions } from "next/router";
 
+declare function routes(opts?: any): Routes;
+export default routes;
+
 export type HTTPHandler = (
   request: IncomingMessage,
   response: ServerResponse
@@ -35,8 +38,19 @@ export interface Router extends SingletonRouter {
   ): Promise<React.ComponentType<any>>;
 }
 
+export interface CustomHandlerRequest {
+  req: IncomingMessage;
+  res: ServerResponse;
+  query: any;
+  route: any;
+}
+
+export type CustomHandler = (
+  request: CustomHandlerRequest 
+) => any;
+
 export interface Registry {
-  getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
+  getRequestHandler(app: Server, custom?: CustomHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
   add(options: { name: string; pattern?: string; page?: string }): this;
@@ -44,8 +58,8 @@ export interface Registry {
   Router: Router;
 }
 
-export default class Routes implements Registry {
-  getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
+export class Routes implements Registry {
+  getRequestHandler(app: Server, custom?: CustomHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
   add(options: { name: string; pattern?: string; page?: string }): this;

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -2,7 +2,7 @@ import * as http from "http";
 import * as next from "next";
 import Routes from "../..";
 
-const routes = new Routes();
+const routes = Routes();
 
 routes
   .add("login")
@@ -14,7 +14,9 @@ routes
 export const createServer = () => {
   const app = next({ dev: true });
   return app.prepare().then(() => {
-    return http.createServer(routes.getRequestHandler(app));
+    return http.createServer(routes.getRequestHandler(app, ({ req, res, route, query }) => {
+      return app.render(req, res, route.page, query);
+    }));
   });
 };
 


### PR DESCRIPTION
Types are broken when using typescript because the default export for it differs from the actual code.