### PR TITLE
add try catch to decodeURIComponent call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-routes",
-  "version": "1.4.2",
+  "version": "1.5.0-beta",
   "description": "Easy to use universal dynamic routes for Next.js",
   "repository": "fridays/next-routes",
   "main": "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -138,9 +138,13 @@ class Route {
   valuesToParams (values) {
     return values.reduce((params, val, i) => {
       if (val === undefined) return params
-      return Object.assign(params, {
-        [this.keys[i].name]: decodeURIComponent(val)
-      })
+      try {
+        return Object.assign(params, {
+          [this.keys[i].name]: decodeURIComponent(val)
+        })
+      } catch (e) {
+        return params
+      }
     }, {})
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class Routes {
       if (result.route) return result
       const params = route.match(pathname)
       if (!params) return result
-      return {...result, route, params, query: {...query, ...params}}
+      return {...result, route, params: {...query, ...params}, query: {...query, ...params}}
     }, {query, parsedUrl})
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -59,6 +59,12 @@ describe('Routes', () => {
     setup('index', '/').testRoute({page: '/'})
   })
 
+  test('merge query string into params', () => {
+    const routes = nextRoutes().add('a', '/a/:slug/reviews')
+    const {params} = routes.match('/a/some-slug/reviews?page=1')
+    expect(params).toMatchObject({slug: 'some-slug', page: '1'})
+  })
+
   test('match and merge params into query', () => {
     const routes = nextRoutes().add('a').add('b', '/:a?/b/:b').add('c')
     const {query} = routes.match('/b/b?b=x&c=c')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -103,6 +103,18 @@ describe('Routes', () => {
     expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
   })
 
+  test('should return params', () => {
+    const {route} = setup('a', '/a/:b')
+    const expected = route.valuesToParams(['/b'])
+    expect(expected).toEqual({b: '/b'})
+  })
+
+  test('should not throw when passed a malformed param', () => {
+    const {route} = setup('a', '/a/:b')
+    const expected = route.valuesToParams(['C0%'])
+    expect(expected).toEqual({})
+  })
+
   test('ensure "as" when path match is empty', () => {
     expect(setup('a', '/:a?').route.getAs()).toEqual('/')
   })


### PR DESCRIPTION
This is to prevent our server from crashing when we pass in a malformed url into the router. Currently when the URL path is malformed we are not catching the error which is causing a 500 error instead of a 404.  