### PR TITLE
 add try catch to decodeURIComponent call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,9 +138,13 @@ class Route {
   valuesToParams (values) {
     return values.reduce((params, val, i) => {
       if (val === undefined) return params
-      return Object.assign(params, {
-        [this.keys[i].name]: decodeURIComponent(val)
-      })
+      try {
+        return Object.assign(params, {
+          [this.keys[i].name]: decodeURIComponent(val)
+        })
+      } catch (e) {
+        return params
+      }
     }, {})
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,6 +97,18 @@ describe('Routes', () => {
     expect(setup('a').route.getUrls()).toEqual({as: '/a', href: '/a?'})
   })
 
+  test('should return params', () => {
+    const {route} = setup('a', '/a/:b')
+    const expected = route.valuesToParams(['/b'])
+    expect(expected).toEqual({b: '/b'})
+  })
+
+  test('should not throw when passed a malformed param', () => {
+    const {route} = setup('a', '/a/:b')
+    const expected = route.valuesToParams(['C0%'])
+    expect(expected).toEqual({})
+  })
+
   test('ensure "as" when path match is empty', () => {
     expect(setup('a', '/:a?').route.getAs()).toEqual('/')
   })


### PR DESCRIPTION
This is to prevent our server from throwing when we pass in a malformed `url` into the router. Currently when the `URL` path is malformed we are not catching the error which is causing a `500 error` instead of a `404`.