### PR TITLE
Add return statement to getRequestHandler middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,13 +77,11 @@ class Routes {
 
       if (route) {
         if (customHandler) {
-          customHandler({req, res, route, query})
-        } else {
-          app.render(req, res, route.page, query)
+          return customHandler({req, res, route, query})
         }
-      } else {
-        nextHandler(req, res, parsedUrl)
+        return app.render(req, res, route.page, query)
       }
+      return nextHandler(req, res, parsedUrl)
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -142,6 +142,38 @@ describe('Request handler', () => {
   })
 })
 
+describe('Request handler (return statement)', () => {
+  const setup = url => {
+    const routes = nextRoutes()
+    const nextHandler = jest.fn()
+    nextHandler.mockResolvedValue('nextHandler')
+    const appRender = jest.fn()
+    appRender.mockResolvedValue('appRender')
+    const app = {getRequestHandler: () => nextHandler, render: appRender}
+    return {app, routes, req: {url}, res: {}}
+  }
+
+  test('find route and call render with returning result', () => {
+    const {routes, app, req, res} = setup('/a')
+    routes.add('a').match('/a')
+    expect(routes.getRequestHandler(app)(req, res)).resolves.toBe('nextHandler')
+  })
+
+  test('find route and call custom handler with returning result', () => {
+    const {routes, app, req, res} = setup('/a')
+    routes.add('a').match('/a')
+    const customHandler = jest.fn()
+    customHandler.mockResolvedValue('customeHandler')
+    expect(routes.getRequestHandler(app, customHandler)(req, res)).resolves.toBe('customeHandler')
+  })
+
+  test('find no route and call next handler with returning result', () => {
+    const {routes, app, req, res} = setup('/a')
+    routes.match('/a')
+    expect(routes.getRequestHandler(app)(req, res)).resolves.toBe('appRender')
+  })
+})
+
 describe('Link', () => {
   const setup = (...args) => {
     const {routes, route} = setupRoute(...args)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -156,7 +156,7 @@ describe('Request handler (return statement)', () => {
   test('find route and call render with returning result', () => {
     const {routes, app, req, res} = setup('/a')
     routes.add('a').match('/a')
-    expect(routes.getRequestHandler(app)(req, res)).resolves.toBe('nextHandler')
+    return expect(routes.getRequestHandler(app)(req, res)).resolves.toBe('appRender')
   })
 
   test('find route and call custom handler with returning result', () => {
@@ -164,13 +164,13 @@ describe('Request handler (return statement)', () => {
     routes.add('a').match('/a')
     const customHandler = jest.fn()
     customHandler.mockResolvedValue('customeHandler')
-    expect(routes.getRequestHandler(app, customHandler)(req, res)).resolves.toBe('customeHandler')
+    return expect(routes.getRequestHandler(app, customHandler)(req, res)).resolves.toBe('customeHandler')
   })
 
   test('find no route and call next handler with returning result', () => {
     const {routes, app, req, res} = setup('/a')
     routes.match('/a')
-    expect(routes.getRequestHandler(app)(req, res)).resolves.toBe('appRender')
+    return expect(routes.getRequestHandler(app)(req, res)).resolves.toBe('nextHandler')
   })
 })
 


### PR DESCRIPTION
This return statement should be there as that functions return promises and getRequestHandler just breaks promise chain.