### PR TITLE
Expose routes as an Array on the Routes class

### DIFF
--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -35,6 +35,8 @@ export interface Router extends SingletonRouter {
   ): Promise<React.ComponentType<any>>;
 }
 
+
+
 export interface Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
@@ -44,6 +46,16 @@ export interface Registry {
   Router: Router;
 }
 
+export interface Route {
+  name: string;
+  pattern: string;
+  page: string;
+  regex: RegExp;
+  keyNames: Array<string>
+  toPath: ( opts: { [index : string ] : any }) => string
+}
+
+
 export default class Routes implements Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
@@ -51,4 +63,5 @@ export default class Routes implements Registry {
   add(options: { name: string; pattern?: string; page?: string }): this;
   Link: ComponentType<LinkProps>;
   Router: Router;
+  routes: Array<Route>
 }

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -35,8 +35,6 @@ export interface Router extends SingletonRouter {
   ): Promise<React.ComponentType<any>>;
 }
 
-
-
 export interface Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;

--- a/typings/tests/allRoutes.ts
+++ b/typings/tests/allRoutes.ts
@@ -1,0 +1,13 @@
+import routes from './basic';
+
+const whiteList : RegExp[] = [];
+
+for (let i = 0; i < routes.routes.length; i++) {
+  const route = routes.routes[i];
+  whiteList.push(new RegExp(`^\\/_next\\/-\\/page\\${route.page}\\.{1}js(\\.map)?$`));
+  whiteList.push(new RegExp(`^\\/_next\\/on-demand-entries-ping\\?page=\\${route.page}$`));
+  whiteList.push(/_next\/webpack\/chunks\/[a-zA-Z\d-_]+\.js$/);
+  whiteList.push(route.regex);
+}
+
+export default whiteList;


### PR DESCRIPTION
To prevent arbitrary file reading in my next application I am using a whitelist in conjunction with next-routes and some custom middleware like so:

```js
  const whiteList = [
    /^\/_next\/webpack-hmr$/,
    /^\/_next\/webpack\/(\d*\.)?[a-z0-9]{20}\.{1}hot-update\.{1}(json|js|js\.map)$/,
    /^\/_next\/static\/commons\/(main|manifest)\.{1}js(\.map)?$/,
    /^\/_next\/-\/page\/(_(app|document|error)|index)\.{1}js(\.map)?$/,
  ];

  for (let i = 0; i < routes.routes.length; i++) {
    const route = routes.routes[i];
    whiteList.push(new RegExp(`^\\/_next\\/-\\/page\\${route.page}\\.{1}js(\\.map)?$`));
    whiteList.push(new RegExp(`^\\/_next\\/on-demand-entries-ping\\?page=\\${route.page}$`));
    whiteList.push(/_next\/webpack\/chunks\/[a-zA-Z\d-_]+\.js$/);
    whiteList.push(route.regex);
  }

  server.use((req, res, n) => {
    const { url } = req;
    let match;
    for (let i = 0; i < whiteList.length; i++) {
      if (url.match(whiteList[i])) {
        match = true;
        break;
      }
    }
  if (match) {
      n();
    } else {
      res.status(404).send('Not Found');
    }
```

Unfortunately, after migrating to TS this no longer works as `routes` is not exposed on the interface. This is a small PR that exposes `routes` for my use case, and anyone else who needs it.