### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
 node_js:
+  - "node"
+  - "10"
+  - "8"
   - "6"
 script: npm run testCI
+install: npm install


### PR DESCRIPTION
Current LTS branches are 6, 8 and 10 and 11 is stable. We should test on all of them to ensure that there are no breaking builds on newer versions.