### PR TITLE
Fix TypeScript types

### DIFF
--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -32,7 +32,7 @@ export interface Router extends SingletonRouter {
   prefetchRoute(
     route: string,
     params?: RouteParams
-  ): Promise<React.ComponentType<any>>;
+  ): Promise<ComponentType<any>>;
 }
 
 export interface Registry {
@@ -44,7 +44,13 @@ export interface Registry {
   Router: Router;
 }
 
-export default class Routes implements Registry {
+type RoutesOptions = {
+  Link?: ComponentType<any>;
+  Router?: Router;
+};
+
+export class Routes implements Registry {
+  constructor(options?: RoutesOptions);
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
@@ -52,3 +58,5 @@ export default class Routes implements Registry {
   Link: ComponentType<LinkProps>;
   Router: Router;
 }
+
+export default function(opts?: RoutesOptions): Routes;

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -1,8 +1,9 @@
 import * as http from "http";
 import * as next from "next";
-import Routes from "../..";
 
-const routes = new Routes();
+import nextRoutes from "../..";
+
+const routes = nextRoutes();
 
 routes
   .add("login")


### PR DESCRIPTION
The TypeScript types were using an incorrect API where the default export was an instance of the class `Routes`. Now the default export is a function that returns a `new Routes()`, so I've fixed and updated the test to match the new(?) API 🙂 