### PR TITLE
fix type of  next-routes.d.ts for shallow option

### DIFF
--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -10,7 +10,7 @@ export type HTTPHandler = (
 ) => void;
 
 export type RouteParams = {
-  [k: string]: string | number;
+  [k: string]: string | number | boolean;
 };
 
 export interface LinkProps extends LinkState {


### PR DESCRIPTION
### CHANGES
* add `boolean` type for `{ shallow: true|false }`

### EXAMPLES

```js
        Router.replaceRoute('/foobar', {
          shallow: true
        })
```