### PR TITLE
Fix default export type

### DIFF
--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -44,7 +44,7 @@ export interface Registry {
   Router: Router;
 }
 
-export default class Routes implements Registry {
+export class Routes implements Registry {
   getRequestHandler(app: Server, custom?: HTTPHandler): HTTPHandler;
   add(name: string, pattern?: string, page?: string): this;
   add(pattern: string, page: string): this;
@@ -52,3 +52,8 @@ export default class Routes implements Registry {
   Link: ComponentType<LinkProps>;
   Router: Router;
 }
+
+export default function router(opts: {
+  Link: React.ComponentType<any>;
+  Router: React.ComponentType<any>;
+}): Routes;

--- a/typings/next-routes.d.ts
+++ b/typings/next-routes.d.ts
@@ -53,7 +53,7 @@ export class Routes implements Registry {
   Router: Router;
 }
 
-export default function router(opts: {
-  Link: React.ComponentType<any>;
-  Router: React.ComponentType<any>;
+export default function router(opts?: {
+  Link?: React.ComponentType<any>;
+  Router?: React.ComponentType<any>;
 }): Routes;

--- a/typings/tests/basic.ts
+++ b/typings/tests/basic.ts
@@ -1,6 +1,6 @@
 import * as http from "http";
 import * as next from "next";
-import Routes from "../..";
+import { Routes } from "../..";
 
 const routes = new Routes();
 


### PR DESCRIPTION
PR for fixing default export from Router class to router() function
(https://github.com/fridays/next-routes/pull/153)